### PR TITLE
fix: catching display init error when not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+.vscode/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/src/Linux/SpyderTallyControllerLinux/SpyderTallyControllerWebApp/Models/RelayRepository.cs
+++ b/src/Linux/SpyderTallyControllerLinux/SpyderTallyControllerWebApp/Models/RelayRepository.cs
@@ -20,11 +20,27 @@ namespace SpyderTallyControllerWebApp.Models
 
             relayStatus = new bool[deviceConfiguration.TallyCount];
 
-            //Initialize GPIO pins
-            gpioController = new GpioController();
-            foreach(var gpioPin in deviceConfiguration.TallyGpioPinAssignments)
+            // Initialize GPIO pins
+            try
             {
-                gpioController.OpenPin(gpioPin.Value, PinMode.Output, PinValue.Low);
+                gpioController = new GpioController();
+                foreach (var gpioPin in deviceConfiguration.TallyGpioPinAssignments)
+                {
+                    try
+                    {
+                        gpioController.OpenPin(gpioPin.Value, PinMode.Output, PinValue.Low);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Failed to open and configure GPIO pin {gpioPin.Value}: {ex.Message}");
+                        // Handle the situation when a specific GPIO pin fails to open, e.g., continue without it
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to initialize GpioController: {ex.Message}");
+                // Handle the situation when GpioController fails to initialize, e.g., continue without GPIO control
             }
         }
 


### PR DESCRIPTION
Resolves a crash on startup that will occur if no display is connected when the Spyder Tallies app starts up.  Fix involved adding try/catch logic around the display I2C initialization and adding a null reference check at the start of the updateDisplay method.  I was able to verify this issue was occurring with the prior release, and that this fixes the issue.

For good measure I also added similar try/catch handling around the I2C pins used for the actual Tally GPIOs, and I write logs to the console in the case these should fail as well.

fixes #11 
